### PR TITLE
Add git to container; Update to latest sbt-extras.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN set -x && \
       openjdk8 \
       openjdk7 \
       git \
+      openssh-client \
       bash
 
 COPY sbt-extras/sbt /bin/sbt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN set -x && \
     apk add --no-cache \
       openjdk8 \
       openjdk7 \
+      git \
       bash
 
 COPY sbt-extras/sbt /bin/sbt


### PR DESCRIPTION
SBT supports `git` URLs, so the container needs a git executable.